### PR TITLE
이미지를 base64포맷으로 받음, 여러 메모의 카테고리를 한번에 변경할 수 있는 api추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ coreschema==0.0.4
 Django==1.11.6
 django-debug-toolbar==1.8
 django-extensions==1.9.7
+django-extra-fields==0.9
 django-rest-auth==0.9.2
 django-rest-swagger==2.1.2
 django-storages==1.6.5


### PR DESCRIPTION
image를 base64포맷으로 받도록 수정, 여러 메모의 카테고리를 한번에 바꿀 수 있도록 views/category, serializer추가 base64이미지필드를 위해 django-extra-fields설치